### PR TITLE
codonw/codonwlib/src\codon_all.c(37): fatal error C1083: can't open f…

### DIFF
--- a/codonw/codonwlib/src/codon_all.c
+++ b/codonw/codonwlib/src/codon_all.c
@@ -34,7 +34,7 @@ genetic code or across the calculation of various codon indicies.
 #include <limits.h>
 #include <stdbool.h>
 
-#include "../include/codonW.h"
+#include "include/codonW.h"
 
 /********************* Initilize Pointers**********************************/
 /* Various pointers to structures are assigned here dependent on the      */


### PR DESCRIPTION
…ile: “../include/codonW.h”: No such file or directory